### PR TITLE
Add DHOM EXPERT ERP layout with tabbed navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,7 @@
           work correctly both with client-side routing and a non-root public URL.
           Learn how to configure a non-root public URL by running `npm run build`.
         -->
-    <title>Vision UI Dashboard Chakra by Creative Tim & Simmmple</title>
+    <title>DHOM EXPERT</title>
     <style>
       @import url(https://cdn.jsdelivr.net/npm/@xz/fonts@1/serve/plus-jakarta-display.min.css);
 

--- a/src/layouts/Admin.js
+++ b/src/layouts/Admin.js
@@ -116,7 +116,7 @@ export default function Dashboard(props) {
     <ChakraProvider theme={theme} resetCss={false}>
       <Sidebar
         routes={routes}
-        logoText={"VISION UI FREE"}
+        logoText={"DHOM EXPERT"}
         display='none'
         sidebarVariant={sidebarVariant}
         {...rest}
@@ -130,7 +130,7 @@ export default function Dashboard(props) {
         <Portal>
           <AdminNavbar
             onOpen={onOpen}
-            logoText={"VISION UI FREE"}
+            logoText={"DHOM EXPERT"}
             brandText={getActiveRoute(routes)}
             secondary={getActiveNavbar(routes)}
             fixed={fixed}

--- a/src/layouts/Auth.js
+++ b/src/layouts/Auth.js
@@ -107,7 +107,7 @@ export default function Pages(props) {
         <Portal containerRef={navRef}>
           <AuthNavbar
             secondary={getActiveNavbar(routes)}
-            logoText='VISION UI FREE'
+            logoText='DHOM EXPERT'
           />
         </Portal>
         <Box w='100%'>

--- a/src/layouts/RTL.js
+++ b/src/layouts/RTL.js
@@ -115,13 +115,13 @@ export default function Dashboard(props) {
   return (
     <ChakraProvider theme={theme} resetCss={false}>
       <RtlProvider>
-        <Sidebar
-          routes={routes}
-          logoText={"VISION UI FREE"}
-          display='none'
-          sidebarVariant={sidebarVariant}
-          {...rest}
-        />
+      <Sidebar
+        routes={routes}
+        logoText={"DHOM EXPERT"}
+        display='none'
+        sidebarVariant={sidebarVariant}
+        {...rest}
+      />
         <MainPanel
           variant='rtl'
           ref={mainPanel}
@@ -130,14 +130,14 @@ export default function Dashboard(props) {
             xl: "calc(100% - 275px)",
           }}>
           <Portal>
-            <AdminNavbar
-              onOpen={onOpen}
-              logoText={"VISION UI FREE"}
-              brandText={getActiveRoute(routes)}
-              secondary={getActiveNavbar(routes)}
-              fixed={fixed}
-              {...rest}
-            />
+              <AdminNavbar
+                onOpen={onOpen}
+                logoText={"DHOM EXPERT"}
+                brandText={getActiveRoute(routes)}
+                secondary={getActiveNavbar(routes)}
+                fixed={fixed}
+                {...rest}
+              />
           </Portal>
           {getRoute() ? (
             <PanelContent>

--- a/src/routes.js
+++ b/src/routes.js
@@ -24,6 +24,7 @@ import RTLPage from "views/RTL/RTLPage.js";
 import Profile from "views/Dashboard/Profile.js";
 import SignIn from "views/Pages/SignIn.js";
 import SignUp from "views/Pages/SignUp.js";
+import DhomExpert from "views/ERP/DhomExpert.js";
 
 import {
   HomeIcon,
@@ -36,6 +37,14 @@ import {
 } from "components/Icons/Icons";
 
 var dashRoutes = [
+  {
+    path: "/dhom-expert",
+    name: "DHOM EXPERT",
+    rtlName: "DHOM EXPERT",
+    icon: <HomeIcon color='inherit' />,
+    component: DhomExpert,
+    layout: "/admin",
+  },
   {
     path: "/dashboard",
     name: "Dashboard",

--- a/src/views/ERP/DhomExpert.js
+++ b/src/views/ERP/DhomExpert.js
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  IconButton,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  VStack,
+} from "@chakra-ui/react";
+import { HamburgerIcon } from "@chakra-ui/icons";
+
+const AREAS = [
+  { key: "comercial", label: "Comercial" },
+  { key: "compras", label: "Compras" },
+  { key: "financeiro", label: "Financeiro" },
+  { key: "fiscal", label: "Fiscal" },
+];
+
+export default function DhomExpert() {
+  const [tabs, setTabs] = useState([]);
+  const [isMenuOpen, setMenuOpen] = useState(true);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const openTab = (area) => {
+    let index = tabs.findIndex((t) => t.key === area.key);
+    if (index === -1) {
+      setTabs([...tabs, area]);
+      index = tabs.length;
+    }
+    setActiveIndex(index);
+    setMenuOpen(false);
+  };
+
+  return (
+    <Box p="4">
+      <IconButton
+        aria-label="Abrir menu"
+        icon={<HamburgerIcon />}
+        mb={4}
+        onClick={() => setMenuOpen(!isMenuOpen)}
+      />
+      {isMenuOpen && (
+        <VStack align="stretch" mb={4} spacing={2}>
+          {AREAS.map((area) => (
+            <Button key={area.key} onClick={() => openTab(area)}>
+              {area.label}
+            </Button>
+          ))}
+        </VStack>
+      )}
+      {tabs.length > 0 && (
+        <Tabs
+          index={activeIndex}
+          onChange={setActiveIndex}
+          isLazy
+          variant="enclosed"
+        >
+          <TabList>
+            {tabs.map((tab) => (
+              <Tab key={tab.key}>{tab.label}</Tab>
+            ))}
+          </TabList>
+          <TabPanels>
+            {tabs.map((tab) => (
+              <TabPanel key={tab.key}>
+                Conteúdo da área {tab.label}.
+              </TabPanel>
+            ))}
+          </TabPanels>
+        </Tabs>
+      )}
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- rename app branding to DHOM EXPERT
- add ERP page with area-based menu opening content in tabs
- register ERP page in routes

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run lint:check` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689e84f7dde8832187a3011aba0cfc18